### PR TITLE
fix typo on ancient_debris tag

### DIFF
--- a/src/main/resources/data/servshred/tags/blocks/veinmine.json
+++ b/src/main/resources/data/servshred/tags/blocks/veinmine.json
@@ -9,6 +9,6 @@
     "#minecraft:iron_ores",
     "#minecraft:lapis_ores",
     "#minecraft:redstone_ores",
-    "minercraft:ancient_debris"
+    "minecraft:ancient_debris"
   ]
 }


### PR DESCRIPTION
[06:45:14] [Worker-Main-1/ERROR]: Couldn't load tag servshred:veinmine as it is missing following references: minercraft:ancient_debris (from ServShred)