### PR TITLE
Update to 1.18.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
     modImplementation "net.fabricmc:fabric-language-kotlin:${project.fabric_kotlin_version}"
 
-    modImplementation 'com.github.P03W:Microconfig:2.1.2'
-    include 'com.github.P03W:Microconfig:2.1.2'
+    modImplementation 'com.github.P03W:Microconfig:2.2.1'
+    include 'com.github.P03W:Microconfig:2.2.1'
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # Check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17
-yarn_mappings=1.17+build.6
-loader_version=0.11.6
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.2
+loader_version=0.13.3
 
 #Fabric api
-fabric_version=0.34.10+1.17
+fabric_version=0.48.0+1.18.2
 
-loom_version=0.8-SNAPSHOT
+loom_version=0.11-SNAPSHOT
 
 # Mod Properties
-mod_version = 1.0.7
+mod_version = 1.0.8
 maven_group = com.github.p03w
 archives_base_name = servshred
 

--- a/src/main/kotlin/com/github/p03w/servshred/ServShredMain.kt
+++ b/src/main/kotlin/com/github/p03w/servshred/ServShredMain.kt
@@ -4,21 +4,25 @@ import mc.microconfig.MicroConfig
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents
+import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.entity.damage.DamageSource
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.stat.Stats
 import net.minecraft.tag.BlockTags
+import net.minecraft.tag.TagKey
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
+import net.minecraft.util.registry.Registry
 
 
 class ServShredMain : ModInitializer {
+    val SHRED_ORES: TagKey<Block> = TagKey.of<Block>(Registry.BLOCK_KEY, Identifier
+        ("servshred", "veinmine"))
     fun blockIsMinable(blockState: BlockState): Boolean {
-        val tag = BlockTags.getTagGroup().getTagOrEmpty(Identifier("servshred:veinmine"))
-        return tag.contains(blockState.block)
+        return blockState.streamTags().toList().contains(SHRED_ORES);
     }
 
     override fun onInitialize() {


### PR DESCRIPTION
Updated the microconfig dependency, loom, fabric api, loader and minecraft versions, yarn mappings

added a TagKey for mineable blocks and rewrote blockIsMinable to check for TagKey on the passed blockState