### PR TITLE
Fixing 1.19.3 registry changes, updating Kotlin, Fabric Kotlin, Loom …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,20 +3,20 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 # Check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.2
-loader_version=0.13.3
+minecraft_version=1.19.3
+yarn_mappings=1.19.3+build.2
+loader_version=0.14.11
 
 #Fabric api
-fabric_version=0.48.0+1.18.2
+fabric_version=0.68.1+1.19.3
 
-loom_version=0.11-SNAPSHOT
+loom_version=1.0-SNAPSHOT
 
 # Mod Properties
-mod_version = 1.0.8
+mod_version = 1.0.9
 maven_group = com.github.p03w
 archives_base_name = servshred
 
 # Kotlin
-kotlin_version=1.5.21
-fabric_kotlin_version=1.6.3+kotlin.1.5.21
+kotlin_version=1.7.22
+fabric_kotlin_version=1.8.7+kotlin.1.7.22

--- a/src/main/kotlin/com/github/p03w/servshred/ServShredMain.kt
+++ b/src/main/kotlin/com/github/p03w/servshred/ServShredMain.kt
@@ -7,19 +7,19 @@ import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents
 import net.minecraft.block.Block
 import net.minecraft.block.BlockState
 import net.minecraft.entity.damage.DamageSource
+import net.minecraft.registry.RegistryKeys
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.stat.Stats
-import net.minecraft.tag.BlockTags
-import net.minecraft.tag.TagKey
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
 import net.minecraft.util.math.Direction
-import net.minecraft.util.registry.Registry
+import net.minecraft.registry.tag.TagKey
 
 
 class ServShredMain : ModInitializer {
-    val SHRED_ORES: TagKey<Block> = TagKey.of<Block>(Registry.BLOCK_KEY, Identifier
+    val SHRED_ORES: TagKey<Block> = TagKey.of<Block>(
+        RegistryKeys.BLOCK, Identifier
         ("servshred", "veinmine"))
     fun blockIsMinable(blockState: BlockState): Boolean {
         return blockState.streamTags().toList().contains(SHRED_ORES);


### PR DESCRIPTION
…and Fabric

Fabric 1.19.3 splits the registry into 3 classes, I made the appropriate changes